### PR TITLE
Fix use/import issue

### DIFF
--- a/cs-config.php
+++ b/cs-config.php
@@ -15,7 +15,12 @@ return [
     'multiline_whitespace_before_semicolons'=> ['strategy' => 'no_multi_line'],
     'no_unused_imports' => true,
     'ordered_imports' => ['sort_algorithm' => 'alpha'],
-    
+    'global_namespace_import' => [
+        'import_classes' => true,
+        'import_constants' => true,
+        'import_functions' => null
+    ],
+
     'no_null_property_initialization' => false,
     'no_superfluous_phpdoc_tags' => false,
     'phpdoc_align' => false,


### PR DESCRIPTION
This will produce this:

```

class Toto {
    pubic function test() {
      \Tata::test();
   }

}

```

Will be turned into

```
use Tata;

class Toto {
    pubic function test() {
      Tata::test();
   }

}

```


This seems to be the default behaviour from the cs fixer rules `no_leading_import_slash` but this doesn't works or conflict with the rules defined here.

The rule we use: https://mlocati.github.io/php-cs-fixer-configurator/#version:3.13|fixer:global_namespace_import

Slack thread: https://bepark.slack.com/archives/G01FSDH6XGU/p1669235959991849
