### PR TITLE
Add configuration class types for 'php_unit_internal_class'

### DIFF
--- a/cs-config.php
+++ b/cs-config.php
@@ -30,7 +30,7 @@ return [
     'phpdoc_single_line_var_spacing' => false,
     'phpdoc_summary' => false,
     'phpdoc_var_annotation_correct_order' => false,
-    'php_unit_internal_class' => [],
+    'php_unit_internal_class' => ['types' => ['normal', 'final', 'abstract']],
     'php_unit_test_class_requires_covers' => false,
     'single_line_comment_style' => false,
     'single_line_empty_body' => false,

--- a/cs-config.php
+++ b/cs-config.php
@@ -30,7 +30,7 @@ return [
     'phpdoc_single_line_var_spacing' => false,
     'phpdoc_summary' => false,
     'phpdoc_var_annotation_correct_order' => false,
-    'php_unit_internal_class' => ['types' => ['normal', 'final', 'abstract']],
+    'php_unit_internal_class' => ['types' => []],
     'php_unit_test_class_requires_covers' => false,
     'single_line_comment_style' => false,
     'single_line_empty_body' => false,


### PR DESCRIPTION
Added class types since it is required to not be an empty array.

In the latest change for the phpCSFixer In FixerFactory.php line 164 configuration can't be an empty array.
                                                                               
  [PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException (32)]  
  [php_unit_internal_class] Configuration must be an array and may not be empty.      